### PR TITLE
Fix SymphonyElixir.Version coverage gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 - 本地运行 `mix test` / `make -C elixir all` 时，应用会在测试前读取仓库的 `elixir/WORKFLOW.md` 并尝试启动 `server.port`（当前为 `40013`）。如果本机该端口已被占用，验证前临时把 `server.port` 改为 `null`（验证后恢复），或者在 BEAM 启动前把 `:workflow_file_path` 指向无服务端口的临时 workflow。
 - 测试环境不要依赖宿主机 `GITHUB_PROJECT_OWNER` / `GITHUB_PROJECT_NUMBER` / `LINEAR_API_KEY` / `LINEAR_PROJECT_SLUG`；`elixir/test/support/test_support.exs` 已在每个测试前清理这些变量并在退出时恢复。
+- 当前 `gh` CLI 使用的 token 缺少 `read:org` scope；`gh pr view` / `gh pr edit` 这类走 GraphQL 的命令可能失败。遇到 PR 元数据更新或读取时，优先使用 REST `gh api repos/<owner>/<repo>/pulls|issues/...`，或使用会话内的 `github_graphql` 工具。

--- a/SPEC.md
+++ b/SPEC.md
@@ -2635,3 +2635,63 @@ Required behavior:
   summary data is present.
 - Rollback is low risk: the change is isolated to the optional observability surface plus its
   snapshot contract.
+
+## 21. Issue 19 Coverage Remediation Plan
+
+### 21.1 Scope
+
+The CI gate currently fails because `make -C elixir coverage` reports `99.49%` total coverage while
+the repository enforces a `100.00%` threshold. The only uncovered module is
+`SymphonyElixir.Version`, whose current tests only exercise the Mix-generated charlist `:vsn`
+shape (`~c"0.3.0"`) returned by `Application.spec(:symphony_elixir, :vsn)` in the test runtime.
+
+Required behavior:
+
+- Keep the runtime contract of `SymphonyElixir.Version.current/0`: it must always return a string.
+- Normalize binary version metadata by returning it unchanged.
+- Normalize charlist version metadata via `List.to_string/1`.
+- Fall back to `"dev"` when the application metadata is missing or not a binary/charlist.
+- Restore the coverage gate without lowering the threshold and without adding production logic that
+  exists only to satisfy tests.
+
+### 21.2 Affected Boundaries
+
+- `Types`: no new external domain types are required; the public version value remains a string.
+- `Config`: no workflow or environment contract changes are expected.
+- `Repo`: no tracker, filesystem, or network repository changes are required.
+- `Service` / `Runtime`: refine `SymphonyElixir.Version` so raw BEAM application metadata is parsed
+  through one deterministic normalization boundary, while `SymphonyElixir.Codex.AppServer`
+  continues to consume only the normalized string.
+- `UI`: no dashboard or HTTP surface changes are expected.
+- `Tests`: add targeted unit coverage for the supported binary, charlist, and fallback metadata
+  shapes plus one smoke assertion that the zero-arity runtime entrypoint still returns a string.
+
+### 21.3 Milestones
+
+1. Isolate the raw-version normalization path in `elixir/lib/symphony_elixir/version.ex` so every
+   supported metadata shape can be exercised deterministically in tests without mutating global app
+   state ad hoc.
+2. Add focused tests under `elixir/test/symphony_elixir/` that cover binary metadata, charlist
+   metadata, unsupported/nil metadata, and the existing runtime entrypoint.
+3. Re-run coverage and the full Elixir gate to prove the module reaches `100.00%` coverage and the
+   repository-level CI command passes unchanged.
+
+### 21.4 Test Plan
+
+- Run `cd elixir && mix specs.check` after updating this specification.
+- Run `cd elixir && mix test test/symphony_elixir/version_test.exs` after implementation to verify
+  every supported version-metadata shape.
+- Run `make -C elixir coverage` after implementation to confirm the strict `100.00%` coverage gate.
+- Run `make -C elixir all` after implementation to verify the full local CI path still passes.
+
+### 21.5 Compatibility, Risks, and Rollback
+
+- `SymphonyElixir.Codex.AppServer` and any future callers must continue receiving a plain string;
+  there is no acceptable behavior change at that call site.
+- The implementation must avoid scattering type checks across callers; raw `:vsn` parsing belongs
+  in `SymphonyElixir.Version` as the single boundary for this metadata.
+- The main risk is introducing a test seam that leaks unnecessary API surface. If an auxiliary
+  function is required for deterministic tests, keep it narrowly scoped and aligned with the real
+  runtime parsing boundary.
+- Rollback is low risk: revert the `Version` refactor and its focused tests without touching
+  workflow, tracker, or release contracts.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2678,11 +2678,11 @@ Required behavior:
 
 ### 21.4 Test Plan
 
-- Run `cd elixir && mix specs.check` after updating this specification.
-- Run `cd elixir && mix test test/symphony_elixir/version_test.exs` after implementation to verify
+- During spec review, run `cd elixir && mix specs.check` after any edits to this specification.
+- After implementation, run `cd elixir && mix test test/symphony_elixir/version_test.exs` to verify
   every supported version-metadata shape.
-- Run `make -C elixir coverage` after implementation to confirm the strict `100.00%` coverage gate.
-- Run `make -C elixir all` after implementation to verify the full local CI path still passes.
+- After implementation, run `make -C elixir coverage` to confirm the strict `100.00%` coverage gate.
+- After implementation, run `make -C elixir all` to verify the full local CI path still passes.
 
 ### 21.5 Compatibility, Risks, and Rollback
 

--- a/elixir/lib/symphony_elixir/version.ex
+++ b/elixir/lib/symphony_elixir/version.ex
@@ -5,9 +5,17 @@ defmodule SymphonyElixir.Version do
 
   @spec current() :: String.t()
   def current do
-    case Application.spec(:symphony_elixir, :vsn) do
-      version when is_binary(version) -> version
-      version when is_list(version) -> List.to_string(version)
+    :symphony_elixir
+    |> Application.spec(:vsn)
+    |> normalize()
+  end
+
+  @doc false
+  @spec normalize(term()) :: String.t()
+  def normalize(version) do
+    case version do
+      value when is_binary(value) -> value
+      value when is_list(value) -> List.to_string(value)
       _ -> "dev"
     end
   end

--- a/elixir/test/symphony_elixir/version_test.exs
+++ b/elixir/test/symphony_elixir/version_test.exs
@@ -1,0 +1,26 @@
+defmodule SymphonyElixir.VersionTest do
+  use ExUnit.Case, async: true
+
+  alias SymphonyElixir.Version
+
+  describe "normalize/1" do
+    test "returns binaries unchanged" do
+      assert Version.normalize("0.3.0") == "0.3.0"
+    end
+
+    test "converts charlists to strings" do
+      assert Version.normalize(~c"0.3.0") == "0.3.0"
+    end
+
+    test "falls back to dev for unsupported metadata" do
+      assert Version.normalize(nil) == "dev"
+    end
+  end
+
+  test "current/0 returns a normalized string" do
+    version = Version.current()
+
+    assert is_binary(version)
+    assert version != ""
+  end
+end


### PR DESCRIPTION
#### Context

Coverage CI is blocked because `SymphonyElixir.Version` only hit the charlist `:vsn` path in tests while the repository still enforces a strict 100% threshold. This PR ships the reviewed spec plus the implementation that restores the existing gate without weakening CI.

Refs BetterAndBetterII/symphony#19.

#### TL;DR

*Normalize raw app version metadata in one place and add focused tests so coverage returns to 100%.*

#### Summary

- route `SymphonyElixir.Version.current/0` through a single `normalize/1` parsing boundary
- add focused tests for binary, charlist, fallback, and runtime smoke coverage in `version_test.exs`
- keep the reviewed Issue 19 remediation plan in `SPEC.md` and document the `gh` scope fallback in `AGENTS.md`

#### Alternatives

- lower the coverage threshold; rejected because the issue is specifically to restore the existing CI gate
- mutate global application metadata in tests; rejected because a pure normalization boundary is simpler and safer
- add dead production branches just to satisfy coverage; rejected because the implementation should match the real runtime parse boundary

#### Test Plan

- [x] `make -C elixir all`
- [x] `cd elixir && mix test test/symphony_elixir/version_test.exs`
- [x] `make -C elixir coverage`
- [x] `cd elixir && mix specs.check`
